### PR TITLE
Refactor normalization, evaluation, and preview generation for z-scored training

### DIFF
--- a/callbacks/CallbackPipeline.py
+++ b/callbacks/CallbackPipeline.py
@@ -62,7 +62,8 @@ class CallbackPipeline:
             loss: Loss object used for callback-side logging and early stopping.
             early_stopping_counter_threshold: Number of non-improving epochs before stop.
             image_savers: Optional saver callable or list of saver callables.
-            image_postprocessor: Postprocessor applied when needed before logging.
+            image_postprocessor: Prediction postprocessor and inverse-transform
+                helper shared by evaluation, artifact export, and signature inference.
             batch_log_every_n: Batch interval for progress logging.
             batch_metric_log_every_n: Batch interval for MLflow batch loss metrics.
             max_eval_batches: Optional cap on batches during callback evaluation.

--- a/callbacks/early_stopping.py
+++ b/callbacks/early_stopping.py
@@ -26,7 +26,8 @@ class EarlyStoppingAndCheckpointCallback(BaseCallback):
 
         Args:
             early_stopping_counter_threshold: Number of non-improving epochs before stop.
-            image_postprocessor: Postprocessor used before signature inference.
+            image_postprocessor: Prediction postprocessor shared with training
+                and used before MLflow signature inference.
             use_amp: Whether to run signature inference under AMP autocast.
         """
         self.early_stopping_counter_threshold = early_stopping_counter_threshold

--- a/callbacks/evaluation.py
+++ b/callbacks/evaluation.py
@@ -28,7 +28,8 @@ class EpochEvaluatorCallback(BaseCallback):
         Args:
             metrics: Metrics updated on each evaluation batch.
             loss: Loss metric object updated on each evaluation batch.
-            image_postprocessor: Postprocessor applied when logits are not used.
+            image_postprocessor: Prediction postprocessor and inverse-transform
+                helper used to denormalize tensors for logging.
             max_eval_batches: Optional cap on evaluation batches per split.
             use_amp: Whether to run evaluation inference under AMP autocast.
         """
@@ -38,7 +39,6 @@ class EpochEvaluatorCallback(BaseCallback):
         self.max_eval_batches = max_eval_batches
         self.use_amp = use_amp
         self.amp_dtype = torch.bfloat16
-        self.compute_sigmoid = any(not metric.use_logits for metric in [*metrics, loss])
 
     def on_epoch_end(self, hook_data: dict[str, Any]) -> None:
         """Run evaluation on train and validation splits.
@@ -90,21 +90,24 @@ class EpochEvaluatorCallback(BaseCallback):
                     dtype=self.amp_dtype,
                 ):
                     generated_predictions = model(samples["input"])
-                    sigmoid_generated_predictions = generated_predictions.clone()
+                    postprocessed_predictions = self.image_postprocessor(
+                        generated_predictions
+                    )
 
-                    # Only postprocess if any metric/loss expects non-logit values.
-                    if self.compute_sigmoid:
-                        sigmoid_generated_predictions = self.image_postprocessor(
-                            generated_predictions
-                        )
+                denormalized_predictions = self.image_postprocessor.denormalize_target(
+                    postprocessed_predictions
+                )
+                denormalized_targets = self.image_postprocessor.denormalize_target(
+                    samples["target"]
+                )
 
                 self.loss.update(
                     generated_predictions=(
                         generated_predictions
                         if self.loss.use_logits
-                        else sigmoid_generated_predictions
+                        else denormalized_predictions
                     ),
-                    targets=samples["target"],
+                    targets=(samples["target"] if self.loss.use_logits else denormalized_targets),
                     loss_mask=samples.get("loss_mask"),
                 )
 
@@ -113,9 +116,9 @@ class EpochEvaluatorCallback(BaseCallback):
                         generated_predictions=(
                             generated_predictions
                             if metric.use_logits
-                            else sigmoid_generated_predictions
+                            else denormalized_predictions
                         ),
-                        targets=samples["target"],
+                        targets=(samples["target"] if metric.use_logits else denormalized_targets),
                         loss_mask=samples.get("loss_mask"),
                     )
 

--- a/callbacks/utils/SaveEpochCrops.py
+++ b/callbacks/utils/SaveEpochCrops.py
@@ -40,15 +40,18 @@ class SaveEpochCrops:
         image: torch.Tensor,
         metadata: dict[str, Any],
         epoch: int,
+        display_bounds: tuple[float, float] | None = None,
     ) -> None:
-        """Convert a tensor image to uint8 and log it as an MLflow artifact.
+        """Convert a denormalized tensor image to uint8 and log it as an artifact.
 
         Args:
             image_path: Source path used to derive filename metadata.
             image_type: Prefix describing the image role (input/target/prediction).
-            image: Image tensor with shape ``(H, W)`` or ``(1, H, W)``.
+            image: Denormalized image tensor with shape ``(H, W)`` or ``(1, H, W)``.
             metadata: Per-image metadata used for artifact path construction.
             epoch: Current epoch index used in artifact paths.
+            display_bounds: Optional lower/upper clipping bounds applied before
+                uint8 rescaling.
 
         Raises:
             ValueError: If image is not convertible to a single 2D crop.
@@ -60,8 +63,7 @@ class SaveEpochCrops:
         if image.ndim != 2:
             raise ValueError(f"Expected image shape (H, W), got {tuple(image.shape)}")
 
-        image = image.clamp(0.0, 1.0)
-        image_np = (image * 255).byte().cpu().numpy()
+        image_np = self._to_display_uint8(image=image, display_bounds=display_bounds)
 
         if np.max(image_np) == 0:
             return
@@ -82,6 +84,60 @@ class SaveEpochCrops:
             save_image_path_folder=save_image_path_folder,
             image_filename=image_filename,
         )
+
+    def _compute_percentile_bounds(
+        self,
+        image: torch.Tensor,
+        lower_percentile: float = 1.0,
+        upper_percentile: float = 99.0,
+    ) -> tuple[float, float]:
+        """Compute robust display bounds from one denormalized image tensor."""
+
+        image_np = image.detach().float().cpu().numpy()
+        lower = float(np.percentile(image_np, lower_percentile))
+        upper = float(np.percentile(image_np, upper_percentile))
+        if not np.isfinite(lower) or not np.isfinite(upper) or lower >= upper:
+            lower = float(np.min(image_np))
+            upper = float(np.max(image_np))
+        if lower >= upper:
+            upper = lower + 1.0
+        return lower, upper
+
+    def _to_display_uint8(
+        self,
+        image: torch.Tensor,
+        display_bounds: tuple[float, float] | None = None,
+    ) -> np.ndarray:
+        """Clip a denormalized image and rescale it to displayable uint8 values."""
+
+        lower, upper = (
+            self._compute_percentile_bounds(image=image)
+            if display_bounds is None
+            else display_bounds
+        )
+        image = image.detach().float().clamp(lower, upper)
+        image = (image - lower) / (upper - lower)
+        return (image * 255).byte().cpu().numpy()
+
+    def _compute_shared_pair_bounds(
+        self,
+        target_image: torch.Tensor,
+        prediction_image: torch.Tensor,
+    ) -> tuple[float, float]:
+        """Compute shared percentile bounds for one target/prediction pair."""
+
+        pair_values = torch.cat(
+            [target_image.detach().reshape(-1), prediction_image.detach().reshape(-1)]
+        )
+        pair_np = pair_values.float().cpu().numpy()
+        lower = float(np.percentile(pair_np, 1.0))
+        upper = float(np.percentile(pair_np, 99.0))
+        if not np.isfinite(lower) or not np.isfinite(upper) or lower >= upper:
+            lower = float(np.min(pair_np))
+            upper = float(np.max(pair_np))
+        if lower >= upper:
+            upper = lower + 1.0
+        return lower, upper
 
     def predict_target(self, image: torch.Tensor, model: torch.nn.Module) -> torch.Tensor:
         """Run model inference for one sample and apply postprocessing.
@@ -109,28 +165,41 @@ class SaveEpochCrops:
         for sample_idx in self.image_dataset_idxs:
             sample = self.image_dataset[sample_idx]
             metadata = sample["metadata"]
+            denormalized_input = self.image_postprocessor.denormalize_input(sample["input"])
+            denormalized_target = self.image_postprocessor.denormalize_target(sample["target"])
+            input_display_bounds = self._compute_percentile_bounds(image=denormalized_input)
 
             self.save_image(
                 image_path=sample["input_path"],
                 image_type="input",
-                image=sample["input"],
+                image=denormalized_input,
                 metadata=metadata,
                 epoch=epoch,
+                display_bounds=input_display_bounds,
+            )
+
+            generated_prediction = self.predict_target(image=sample["input"], model=model)
+            denormalized_prediction = self.image_postprocessor.denormalize_target(
+                generated_prediction
+            )
+            pair_display_bounds = self._compute_shared_pair_bounds(
+                target_image=denormalized_target,
+                prediction_image=denormalized_prediction,
             )
 
             self.save_image(
                 image_path=sample["target_path"],
                 image_type="target",
-                image=sample["target"],
+                image=denormalized_target,
                 metadata=metadata,
                 epoch=epoch,
+                display_bounds=pair_display_bounds,
             )
-
-            generated_prediction = self.predict_target(image=sample["input"], model=model)
             self.save_image(
                 image_path=sample["target_path"],
                 image_type="generated_prediction",
-                image=generated_prediction,
+                image=denormalized_prediction,
                 metadata=metadata,
                 epoch=epoch,
+                display_bounds=pair_display_bounds,
             )

--- a/callbacks/utils/save_utils.py
+++ b/callbacks/utils/save_utils.py
@@ -22,7 +22,7 @@ def save_image_mlflow(
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         save_path = pathlib.Path(tmp_dir) / image_filename
-        tifffile.imwrite(save_path, image.astype(np.uint8))
+        tifffile.imwrite(save_path, image)
 
         mlflow.log_artifact(local_path=save_path, artifact_path=save_image_path_folder)
 
@@ -42,4 +42,4 @@ def save_image_locally(
 
     save_image_path_folder = pathlib.Path(save_image_path_folder)
     save_image_path_folder.mkdir(parents=True, exist_ok=True)
-    tifffile.imwrite(save_image_path_folder / image_filename, image.astype(np.uint8))
+    tifffile.imwrite(save_image_path_folder / image_filename, image)

--- a/datasets/dataset_00/CellCropToCropDataset.py
+++ b/datasets/dataset_00/CellCropToCropDataset.py
@@ -134,10 +134,10 @@ class CellCropToCropDataset(Dataset):
         if cache_dir is not None and cache_dir.exists():
             input_image = torch.from_numpy(
                 tifffile.imread(cache_dir / self.input_image_name)
-            ).to(device=self.device)
+            )
             target_image = torch.from_numpy(
                 tifffile.imread(cache_dir / self.target_image_name)
-            ).to(device=self.device)
+            )
         else:
             input_image, target_image = self.process_load_images()
             if cache_dir is not None:

--- a/datasets/dataset_00/utils/ImagePostProcessor.py
+++ b/datasets/dataset_00/utils/ImagePostProcessor.py
@@ -1,29 +1,54 @@
-from typing import Any, Optional, Tuple, Union
-
-import numpy as np
 import torch
-import torch.nn.functional as F
-from torch.amp import autocast
 
 
 class ImagePostProcessor:
-    """
-    Processes generated predictions computed from the model.
-    """
+    """Postprocess model outputs and denormalize tensors for logging/export."""
 
-    def __init__(self):
-        """Initialize postprocessing behavior for generated predictions."""
+    def __init__(
+        self,
+        input_mean: float,
+        input_std: float,
+        target_mean: float,
+        target_std: float,
+    ):
+        """Store train-split normalization statistics for inverse transforms.
 
-        pass
+        Args:
+            input_mean: Mean intensity used to z-score inputs.
+            input_std: Standard deviation used to z-score inputs.
+            target_mean: Mean intensity used to z-score targets.
+            target_std: Standard deviation used to z-score targets.
+
+        Raises:
+            ValueError: If any standard deviation is non-positive.
+        """
+
+        if input_std <= 0 or target_std <= 0:
+            raise ValueError("Z-score standard deviations must be positive")
+
+        self.input_mean = float(input_mean)
+        self.input_std = float(input_std)
+        self.target_mean = float(target_mean)
+        self.target_std = float(target_std)
 
     def __call__(self, generated_prediction: torch.Tensor) -> torch.Tensor:
-        """Apply output activation to model logits.
+        """Return model predictions in training space.
 
         Args:
             generated_prediction: Raw model output tensor.
 
         Returns:
-            Sigmoid-transformed prediction tensor.
+            Prediction tensor in z-score space.
         """
 
-        return torch.sigmoid(generated_prediction)
+        return generated_prediction
+
+    def denormalize_input(self, image: torch.Tensor) -> torch.Tensor:
+        """Map z-scored input tensors back to original intensity space."""
+
+        return image.float() * self.input_std + self.input_mean
+
+    def denormalize_target(self, image: torch.Tensor) -> torch.Tensor:
+        """Map z-scored target or prediction tensors back to original intensity space."""
+
+        return image.float() * self.target_std + self.target_mean

--- a/datasets/dataset_00/utils/ImagePreProcessor.py
+++ b/datasets/dataset_00/utils/ImagePreProcessor.py
@@ -32,20 +32,26 @@ class ImagePreProcessor:
 
     def set_image_specs(
         self,
-        input_max_pixel_value: float,
-        target_max_pixel_value: float,
+        input_mean: float | None = None,
+        input_std: float | None = None,
+        target_mean: float | None = None,
+        target_std: float | None = None,
         **kwargs,
     ) -> None:
-        """Store normalization constants inferred from cached images.
+        """Store z-score normalization statistics inferred from training data.
 
         Args:
-            input_max_pixel_value: Max pixel value used to normalize inputs.
-            target_max_pixel_value: Max pixel value used to normalize targets.
+            input_mean: Mean pixel intensity used to center inputs.
+            input_std: Standard deviation used to scale inputs.
+            target_mean: Mean pixel intensity used to center targets.
+            target_std: Standard deviation used to scale targets.
             **kwargs: Additional image spec keys ignored by this preprocessor.
         """
 
-        self.input_max_pixel_value = float(input_max_pixel_value)
-        self.target_max_pixel_value = float(target_max_pixel_value)
+        self.input_mean = None if input_mean is None else float(input_mean)
+        self.input_std = None if input_std is None else float(input_std)
+        self.target_mean = None if target_mean is None else float(target_mean)
+        self.target_std = None if target_std is None else float(target_std)
 
     def format_img(self, img: np.ndarray) -> torch.Tensor:
         """Convert a normalized 2D numpy image into a channel-first tensor.
@@ -79,7 +85,8 @@ class ImagePreProcessor:
             Dictionary containing formatted ``input_image`` and ``target_image`` tensors.
 
         Raises:
-            ValueError: If normalization constants are non-positive.
+            ValueError: If z-score statistics are missing or standard deviations
+                are non-positive.
         """
 
         if self.input_transform is not None:
@@ -88,11 +95,13 @@ class ImagePreProcessor:
         if self.target_transform is not None:
             target_img = self.target_transform(image=target_img)["image"]
 
-        if self.input_max_pixel_value <= 0 or self.target_max_pixel_value <= 0:
-            raise ValueError("Pixel value normalization constants must be positive")
+        if None in (self.input_mean, self.input_std, self.target_mean, self.target_std):
+            raise ValueError("Z-score normalization statistics must be set before loading data")
+        if self.input_std <= 0 or self.target_std <= 0:
+            raise ValueError("Z-score standard deviations must be positive")
 
-        input_img = input_img / self.input_max_pixel_value
-        target_img = target_img / self.target_max_pixel_value
+        input_img = (input_img - self.input_mean) / self.input_std
+        target_img = (target_img - self.target_mean) / self.target_std
 
         return {
             "input_image": self.format_img(input_img),

--- a/datasets/dataset_00/utils/ImagePreProcessor.py
+++ b/datasets/dataset_00/utils/ImagePreProcessor.py
@@ -69,10 +69,7 @@ class ImagePreProcessor:
         if img.ndim != 2:
             raise ValueError(f"Expected 2D image, got shape {img.shape}")
 
-        return torch.from_numpy(img).unsqueeze(0).to(
-            dtype=torch.float32,
-            device=self.device,
-        )
+        return torch.from_numpy(img).unsqueeze(0).to(dtype=torch.float32)
 
     def __call__(self, input_img: np.ndarray, target_img: np.ndarray) -> dict[str, Any]:
         """Apply transforms, normalize, and format paired images.

--- a/train.py
+++ b/train.py
@@ -287,8 +287,8 @@ class OptimizationManager:
         loss_callbacks = L1(device=device)
         metrics = [
             L2(device=device),
-            PSNR(device=device, max_pixel_value=1.0),
-            SSIM(device=device, max_pixel_value=1.0),
+            PSNR(device=device, max_pixel_value=image_specs["target_max_pixel_value"]),
+            SSIM(device=device, max_pixel_value=image_specs["target_max_pixel_value"]),
             PearsonCorrelation(device=device),
         ]
 
@@ -357,7 +357,8 @@ Optimization of a DAPI-to-Gold image-to-image translation model with:
 - Single 2D crop input and single 2D crop target
 - Cache-backed filtered nucleus crops generated from the configured data directory
 - Train-split z-score normalization for inputs and targets
-- L1 optimization objective with L2, PSNR, SSIM, and Pearson correlation metric logging
+- L1 optimization objective in z-score space with denormalized L2, PSNR, SSIM,
+  and Pearson correlation metric logging
 """
 mlflow.set_tag("mlflow.note.content", description)
 

--- a/train.py
+++ b/train.py
@@ -16,6 +16,7 @@ import mlflow
 import numpy as np
 import optuna
 import torch
+import tifffile
 
 from callbacks.CallbackPipeline import CallbackPipeline
 from callbacks.utils.SampleImages import SampleImages
@@ -150,6 +151,63 @@ requested_eval_batch_size = None if args.eval_batch_size <= 0 else args.eval_bat
 eval_use_amp = args.eval_use_amp == 1
 train_use_amp = args.train_use_amp == 1
 max_batch_size = 8
+
+
+def compute_training_image_stats(
+    manifest_rows: list[dict[str, str]],
+    train_indices: list[int],
+) -> dict[str, float]:
+    """Compute train-split image mean and std for z-score normalization.
+
+    Args:
+        manifest_rows: Full manifest rows backing the crop dataset.
+        train_indices: Dataset indices assigned to the training split.
+
+    Returns:
+        Dictionary containing train-split input/target means and standard deviations.
+
+    Raises:
+        ValueError: If the training split is empty or any variance is non-positive.
+    """
+
+    if not train_indices:
+        raise ValueError("Training split is empty; cannot compute z-score statistics.")
+
+    input_sum = 0.0
+    input_sum_sq = 0.0
+    target_sum = 0.0
+    target_sum_sq = 0.0
+    input_count = 0
+    target_count = 0
+
+    for idx in train_indices:
+        sample = manifest_rows[idx]
+        input_image = tifffile.imread(sample["input_path"]).astype(np.float64)
+        target_image = tifffile.imread(sample["target_path"]).astype(np.float64)
+
+        input_sum += float(input_image.sum())
+        input_sum_sq += float(np.square(input_image).sum())
+        target_sum += float(target_image.sum())
+        target_sum_sq += float(np.square(target_image).sum())
+        input_count += int(input_image.size)
+        target_count += int(target_image.size)
+
+    input_mean = input_sum / input_count
+    target_mean = target_sum / target_count
+    input_var = (input_sum_sq / input_count) - (input_mean**2)
+    target_var = (target_sum_sq / target_count) - (target_mean**2)
+    input_std = math.sqrt(max(input_var, 0.0))
+    target_std = math.sqrt(max(target_var, 0.0))
+
+    if input_std <= 0 or target_std <= 0:
+        raise ValueError("Training-split z-score standard deviations must be positive.")
+
+    return {
+        "input_mean": input_mean,
+        "input_std": input_std,
+        "target_mean": target_mean,
+        "target_std": target_std,
+    }
 
 
 class OptimizationManager:
@@ -298,6 +356,7 @@ Optimization of a DAPI-to-Gold image-to-image translation model with:
 - ConvNeXtUNet Generator
 - Single 2D crop input and single 2D crop target
 - Cache-backed filtered nucleus crops generated from the configured data directory
+- Train-split z-score normalization for inputs and targets
 - L1 optimization objective with L2, PSNR, SSIM, and Pearson correlation metric logging
 """
 mlflow.set_tag("mlflow.note.content", description)
@@ -344,8 +403,40 @@ image_specs = cache_result.image_specs
 mlflow.log_param("input_max_pixel_value", image_specs["input_max_pixel_value"])
 mlflow.log_param("target_max_pixel_value", image_specs["target_max_pixel_value"])
 
+bootstrap_preprocessor = ImagePreProcessor(image_specs=image_specs, device=device)
+
+bootstrap_dataset = CellCropToCropDataset(
+    manifest_rows=manifest_nuclei,
+    image_specs=image_specs,
+    image_preprocessor=bootstrap_preprocessor,
+    image_cache_path=tensor_cache_path,
+)
+
+# HashSplitter uses metadata-derived IDs, so splits stay stable across reruns.
+bootstrap_hash_splitter = HashSplitter(
+    dataset=bootstrap_dataset,
+    train_frac=0.825,
+    val_frac=0.125,
+)
+bootstrap_hash_splitter.split_by_hash()
+training_stats = compute_training_image_stats(
+    manifest_rows=manifest_nuclei,
+    train_indices=bootstrap_hash_splitter.splits["train"],
+)
+image_specs = image_specs | training_stats
+
+mlflow.log_param("input_mean", image_specs["input_mean"])
+mlflow.log_param("input_std", image_specs["input_std"])
+mlflow.log_param("target_mean", image_specs["target_mean"])
+mlflow.log_param("target_std", image_specs["target_std"])
+
 image_preprocessor = ImagePreProcessor(image_specs=image_specs, device=device)
-image_postprocessor = ImagePostProcessor()
+image_postprocessor = ImagePostProcessor(
+    input_mean=image_specs["input_mean"],
+    input_std=image_specs["input_std"],
+    target_mean=image_specs["target_mean"],
+    target_std=image_specs["target_std"],
+)
 
 crop_image_dataset = CellCropToCropDataset(
     manifest_rows=manifest_nuclei,
@@ -354,7 +445,6 @@ crop_image_dataset = CellCropToCropDataset(
     image_cache_path=tensor_cache_path,
 )
 
-# HashSplitter uses metadata-derived IDs, so splits stay stable across reruns.
 hash_splitter = HashSplitter(
     dataset=crop_image_dataset,
     train_frac=0.825,

--- a/train.py
+++ b/train.py
@@ -182,13 +182,13 @@ def compute_training_image_stats(
 
     for idx in train_indices:
         sample = manifest_rows[idx]
-        input_image = tifffile.imread(sample["input_path"]).astype(np.float64)
-        target_image = tifffile.imread(sample["target_path"]).astype(np.float64)
+        input_image = tifffile.imread(sample["input_path"])
+        target_image = tifffile.imread(sample["target_path"])
 
-        input_sum += float(input_image.sum())
-        input_sum_sq += float(np.square(input_image).sum())
-        target_sum += float(target_image.sum())
-        target_sum_sq += float(np.square(target_image).sum())
+        input_sum += float(input_image.sum(dtype=np.float64))
+        input_sum_sq += float(np.square(input_image, dtype=np.float64).sum())
+        target_sum += float(target_image.sum(dtype=np.float64))
+        target_sum_sq += float(np.square(target_image, dtype=np.float64).sum())
         input_count += int(input_image.size)
         target_count += int(target_image.size)
 

--- a/train.py
+++ b/train.py
@@ -474,7 +474,7 @@ val_image_prediction_saver = SaveEpochCrops(
 )
 
 callbacks_args = {
-    "early_stopping_counter_threshold": 5,
+    "early_stopping_counter_threshold": 15,
     "image_savers": (
         [train_image_prediction_saver, val_image_prediction_saver]
         if args.enable_image_savers == 1

--- a/trainers/UNetTrainer.py
+++ b/trainers/UNetTrainer.py
@@ -40,7 +40,8 @@ class UNetTrainer:
             train_dataloader: Training dataloader.
             val_dataloader: Validation dataloader used by callbacks.
             callbacks: Callback dispatcher used for hooks and logging.
-            image_postprocessor: Postprocessor applied to model outputs.
+            image_postprocessor: Postprocessor applied to model outputs before
+                the optimization loss consumes them.
             epochs: Maximum number of training epochs.
             device: Target device for model and tensors.
             use_amp: Whether to use automatic mixed precision autocast during

--- a/training_orchestration.sh
+++ b/training_orchestration.sh
@@ -10,7 +10,7 @@ mlflow run . -e train_model \
   --env-manager local \
   --experiment-name "u2os_nuclear_speckle_prediction_dapi_gold" \
   -P dataset=u2os \
-  -P epochs=20 \
+  -P epochs=100 \
   -P n_trials=15 \
   -P max_train_batches=-1 \
   -P max_eval_batches=-1 \


### PR DESCRIPTION
This pr switches the training pipeline to train-split z-score normalization, removes the output sigmoid so predictions stay aligned with z-scored targets during optimization, computes validation loss and reconstruction metrics in original intensity space, and improves saved example images by denormalizing and applying robust percentile-based display scaling.