### PR TITLE
Add Optuna-weighted SSIM loss and align validation selection

### DIFF
--- a/callbacks/early_stopping.py
+++ b/callbacks/early_stopping.py
@@ -86,14 +86,16 @@ class EarlyStoppingAndCheckpointCallback(BaseCallback):
         """
 
         model.eval()
+        model_device = next(model.parameters()).device
+        model_input = input_example.to(model_device)
         with torch.no_grad():
             with torch.amp.autocast(
                 enabled=self.use_amp,
-                device_type=input_example.device.type,
+                device_type=model_device.type,
                 dtype=self.amp_dtype,
             ):
                 output_example = (
-                    self.image_postprocessor(model(input_example))
+                    self.image_postprocessor(model(model_input))
                     .detach()
                     .float()
                     .cpu()

--- a/callbacks/evaluation.py
+++ b/callbacks/evaluation.py
@@ -81,15 +81,18 @@ class EpochEvaluatorCallback(BaseCallback):
         """
 
         model.eval()
+        model_device = next(model.parameters()).device
 
         with torch.no_grad():
             for batch_idx, samples in enumerate(dataloader):
+                inputs = samples["input"].to(model_device)
+                targets = samples["target"].to(model_device)
                 with torch.amp.autocast(
                     enabled=self.use_amp,
-                    device_type=samples["input"].device.type,
+                    device_type=model_device.type,
                     dtype=self.amp_dtype,
                 ):
-                    generated_predictions = model(samples["input"])
+                    generated_predictions = model(inputs)
                     postprocessed_predictions = self.image_postprocessor(
                         generated_predictions
                     )
@@ -98,7 +101,7 @@ class EpochEvaluatorCallback(BaseCallback):
                     postprocessed_predictions
                 )
                 denormalized_targets = self.image_postprocessor.denormalize_target(
-                    samples["target"]
+                    targets
                 )
 
                 self.loss.update(
@@ -107,7 +110,7 @@ class EpochEvaluatorCallback(BaseCallback):
                         if self.loss.use_logits
                         else denormalized_predictions
                     ),
-                    targets=(samples["target"] if self.loss.use_logits else denormalized_targets),
+                    targets=(targets if self.loss.use_logits else denormalized_targets),
                     loss_mask=samples.get("loss_mask"),
                 )
 
@@ -118,7 +121,7 @@ class EpochEvaluatorCallback(BaseCallback):
                             if metric.use_logits
                             else denormalized_predictions
                         ),
-                        targets=(samples["target"] if metric.use_logits else denormalized_targets),
+                        targets=(targets if metric.use_logits else denormalized_targets),
                         loss_mask=samples.get("loss_mask"),
                     )
 

--- a/callbacks/utils/SaveEpochCrops.py
+++ b/callbacks/utils/SaveEpochCrops.py
@@ -150,9 +150,10 @@ class SaveEpochCrops:
             Postprocessed prediction tensor.
         """
 
+        model_device = next(model.parameters()).device
         with torch.no_grad():
-            prediction = model(image.unsqueeze(0)).squeeze(0)
-        return self.image_postprocessor(prediction)
+            prediction = model(image.unsqueeze(0).to(model_device)).squeeze(0)
+        return self.image_postprocessor(prediction).detach().cpu()
 
     def __call__(self, model: torch.nn.Module, epoch: int) -> None:
         """Save input, target, and generated prediction images for one epoch.

--- a/callbacks/utils/save_utils.py
+++ b/callbacks/utils/save_utils.py
@@ -4,7 +4,6 @@ import tempfile
 import mlflow
 import numpy as np
 import tifffile
-import torch
 
 
 def save_image_mlflow(
@@ -25,21 +24,3 @@ def save_image_mlflow(
         tifffile.imwrite(save_path, image)
 
         mlflow.log_artifact(local_path=save_path, artifact_path=save_image_path_folder)
-
-
-def save_image_locally(
-    image: np.ndarray,
-    save_image_path_folder: str,
-    image_filename: str,
-) -> None:
-    """Write an image to a local output directory as uint8 TIFF.
-
-    Args:
-        image: Image array to save.
-        save_image_path_folder: Output directory path.
-        image_filename: Output filename.
-    """
-
-    save_image_path_folder = pathlib.Path(save_image_path_folder)
-    save_image_path_folder.mkdir(parents=True, exist_ok=True)
-    tifffile.imwrite(save_image_path_folder / image_filename, image)

--- a/datasets/dataset_00/utils/CropCacheBuilder.py
+++ b/datasets/dataset_00/utils/CropCacheBuilder.py
@@ -10,6 +10,9 @@ import tifffile
 from skimage.transform import resize
 
 
+CROP_CACHE_VERSION = "5"
+
+
 @dataclass
 class CropCacheResult:
     """Output metadata returned after building or validating a crop cache.
@@ -551,6 +554,7 @@ def _build_filtered_profiles(
 
 def _validate_manifest(
     manifest_path: pathlib.Path,
+    crop_size: int,
     input_resolution: float | None,
     target_resolution: float | None,
 ) -> tuple[bool, list[dict[str, str]]]:
@@ -558,15 +562,17 @@ def _validate_manifest(
 
     Args:
         manifest_path: Path to the cache CSV manifest.
+        crop_size: Requested fixed crop size.
         input_resolution: Requested source microscope resolution.
         target_resolution: Requested target microscope resolution.
 
     Returns:
         Tuple of (is_valid, rows). Rows are returned only when valid.
 
-    The manifest is reusable only when its cached crop layout, on-disk file
-    paths, and stored resolution settings all match the current request. This
-    forces a rebuild when whole-image resampling settings change.
+    The manifest is reusable only when its cached crop layout, crop builder
+    version, source image selections, on-disk paths, and stored resolution
+    settings all match the current request. This forces a rebuild when
+    whole-image resampling or crop-generation behavior changes.
     """
 
     if not manifest_path.exists():
@@ -589,6 +595,8 @@ def _validate_manifest(
         "target_channel",
         "input_path",
         "target_path",
+        "crop_size",
+        "cache_version",
         "input_resolution",
         "target_resolution",
     }
@@ -603,10 +611,15 @@ def _validate_manifest(
     requested_target_resolution = (
         "" if target_resolution is None else f"{target_resolution:.6f}"
     )
+    requested_crop_size = str(int(crop_size))
 
     for row in rows:
         sample_id = row["sample_id"]
         if not center_x_pattern.search(sample_id) or not center_y_pattern.search(sample_id):
+            return False, []
+        if row["cache_version"] != CROP_CACHE_VERSION:
+            return False, []
+        if row["crop_size"] != requested_crop_size:
             return False, []
         if row["input_resolution"] != requested_input_resolution:
             return False, []
@@ -616,7 +629,10 @@ def _validate_manifest(
         # Reuse is only safe when paths and sample IDs still match on-disk files.
         input_path = pathlib.Path(row["input_path"])
         target_path = pathlib.Path(row["target_path"])
-        if not input_path.exists() or not target_path.exists():
+        if (
+            not input_path.exists()
+            or not target_path.exists()
+        ):
             return False, []
 
         is_legacy_layout = input_path.stem == sample_id and target_path.stem == sample_id
@@ -720,6 +736,7 @@ def ensure_dapi_to_gold_cache(
 
     is_valid, existing_rows = _validate_manifest(
         manifest_path=manifest_path,
+        crop_size=crop_size,
         input_resolution=input_resolution,
         target_resolution=target_resolution,
     )
@@ -807,8 +824,13 @@ def ensure_dapi_to_gold_cache(
                 axis=1,
                 result_type="expand",
             )
-            transformed_bboxes.columns = bbox_cols
-            image_df[bbox_cols] = transformed_bboxes.astype(int)
+            transformed_bboxes.columns = [
+                "Metadata_Nuclei_AreaShape_BoundingBoxMinimum_X",
+                "Metadata_Nuclei_AreaShape_BoundingBoxMinimum_Y",
+                "Metadata_Nuclei_AreaShape_BoundingBoxMaximum_X",
+                "Metadata_Nuclei_AreaShape_BoundingBoxMaximum_Y",
+            ]
+            image_df[transformed_bboxes.columns] = transformed_bboxes.astype(int)
 
         for _, nucleus in image_df.iterrows():
             x0 = int(nucleus["Metadata_Nuclei_AreaShape_BoundingBoxMinimum_X"])
@@ -888,6 +910,8 @@ def ensure_dapi_to_gold_cache(
                     "target_channel": target_channel,
                     "input_path": str(input_path.resolve()),
                     "target_path": str(target_path.resolve()),
+                    "crop_size": str(crop_size),
+                    "cache_version": CROP_CACHE_VERSION,
                     "input_resolution": "" if input_resolution is None else f"{input_resolution:.6f}",
                     "target_resolution": "" if target_resolution is None else f"{target_resolution:.6f}",
                     "cellprofiler_center_x": cellprofiler_center_x,
@@ -911,6 +935,8 @@ def ensure_dapi_to_gold_cache(
                 "target_channel",
                 "input_path",
                 "target_path",
+                "crop_size",
+                "cache_version",
                 "input_resolution",
                 "target_resolution",
                 "cellprofiler_center_x",

--- a/losses/L1SSIMLoss.py
+++ b/losses/L1SSIMLoss.py
@@ -37,13 +37,28 @@ class L1SSIMLoss(nn.Module):
         targets: torch.Tensor,
         **kwargs,
     ) -> dict[str, torch.Tensor]:
-        """Compute composite batch loss for one optimization step."""
+        """Compute composite L1 and SSIM batch loss for one optimization step.
+
+        Args:
+            generated_predictions: Model predictions.
+            targets: Ground-truth targets with matching shape.
+            **kwargs: Additional unused loss arguments.
+
+        Returns:
+            Dictionary containing scalar ``l1``, ``ssim``, and ``total`` loss
+            components, where ``ssim`` stores ``1 - SSIM``.
+
+        Raises:
+            ValueError: If prediction and target shapes differ.
+        """
 
         if generated_predictions.shape != targets.shape:
             raise ValueError("The generated predictions and targets must be the same shape.")
 
         l1 = torch.nn.functional.l1_loss(generated_predictions, targets, reduction="mean")
         if self.data_range is None:
+            # Derive a positive SSIM range from the current batch so the loss can
+            # operate directly in z-score space without a fixed intensity bound.
             batch_max = torch.maximum(generated_predictions.max(), targets.max())
             batch_min = torch.minimum(generated_predictions.min(), targets.min())
             ssim_data_range = (batch_max - batch_min).clamp_min(torch.finfo(torch.float32).eps)

--- a/losses/L1SSIMLoss.py
+++ b/losses/L1SSIMLoss.py
@@ -15,7 +15,7 @@ class L1SSIMLoss(nn.Module):
         """Store SSIM weighting and optional fixed intensity range.
 
         Args:
-            ssim_weight: Multiplier applied to ``1 - ssim``.
+            ssim_weight: Multiplier applied to ``-1 * ssim``.
             data_range: Optional fixed data range for SSIM. If omitted, the
                 range is derived from the current batch.
 
@@ -47,7 +47,7 @@ class L1SSIMLoss(nn.Module):
 
         Returns:
             Dictionary containing scalar ``l1``, ``ssim``, and ``total`` loss
-            components, where ``ssim`` stores ``1 - SSIM``.
+            components, where ``ssim`` stores ``-1 * SSIM``.
 
         Raises:
             ValueError: If prediction and target shapes differ.

--- a/losses/L1SSIMLoss.py
+++ b/losses/L1SSIMLoss.py
@@ -2,7 +2,8 @@ from typing import Optional
 
 import torch
 from torch import nn
-from torchmetrics.functional.image import structural_similarity_index_measure
+
+from .l1_ssim import compute_l1_ssim_mean_components
 
 
 class L1SSIMLoss(nn.Module):
@@ -51,26 +52,9 @@ class L1SSIMLoss(nn.Module):
         Raises:
             ValueError: If prediction and target shapes differ.
         """
-
-        if generated_predictions.shape != targets.shape:
-            raise ValueError("The generated predictions and targets must be the same shape.")
-
-        l1 = torch.nn.functional.l1_loss(generated_predictions, targets, reduction="mean")
-        if self.data_range is None:
-            # Derive a positive SSIM range from the current batch so the loss can
-            # operate directly in z-score space without a fixed intensity bound.
-            batch_max = torch.maximum(generated_predictions.max(), targets.max())
-            batch_min = torch.minimum(generated_predictions.min(), targets.min())
-            ssim_data_range = (batch_max - batch_min).clamp_min(torch.finfo(torch.float32).eps)
-            ssim_data_range = ssim_data_range.to(generated_predictions.dtype)
-        else:
-            ssim_data_range = self.data_range
-
-        ssim = structural_similarity_index_measure(
-            preds=generated_predictions,
-            target=targets,
-            data_range=ssim_data_range,
+        return compute_l1_ssim_mean_components(
+            generated_predictions=generated_predictions,
+            targets=targets,
+            ssim_weight=self.ssim_weight,
+            data_range=self.data_range,
         )
-        ssim_loss = 1.0 - ssim
-        total = l1 + self.ssim_weight * ssim_loss
-        return {"l1": l1, "ssim": ssim_loss, "total": total}

--- a/losses/L1SSIMLoss.py
+++ b/losses/L1SSIMLoss.py
@@ -1,0 +1,61 @@
+from typing import Optional
+
+import torch
+from torch import nn
+from torchmetrics.functional.image import structural_similarity_index_measure
+
+
+class L1SSIMLoss(nn.Module):
+    """Composite training loss combining L1 and SSIM terms."""
+
+    loss_name = "l1_ssim"
+
+    def __init__(self, ssim_weight: float, data_range: Optional[float] = None) -> None:
+        """Store SSIM weighting and optional fixed intensity range.
+
+        Args:
+            ssim_weight: Multiplier applied to ``1 - ssim``.
+            data_range: Optional fixed data range for SSIM. If omitted, the
+                range is derived from the current batch.
+
+        Raises:
+            ValueError: If ``ssim_weight`` is negative or ``data_range`` is not
+                positive when provided.
+        """
+
+        super().__init__()
+        if ssim_weight < 0:
+            raise ValueError("ssim_weight must be non-negative")
+        if data_range is not None and data_range <= 0:
+            raise ValueError("data_range must be positive when provided")
+        self.ssim_weight = float(ssim_weight)
+        self.data_range = None if data_range is None else float(data_range)
+
+    def forward(
+        self,
+        generated_predictions: torch.Tensor,
+        targets: torch.Tensor,
+        **kwargs,
+    ) -> dict[str, torch.Tensor]:
+        """Compute composite batch loss for one optimization step."""
+
+        if generated_predictions.shape != targets.shape:
+            raise ValueError("The generated predictions and targets must be the same shape.")
+
+        l1 = torch.nn.functional.l1_loss(generated_predictions, targets, reduction="mean")
+        if self.data_range is None:
+            batch_max = torch.maximum(generated_predictions.max(), targets.max())
+            batch_min = torch.minimum(generated_predictions.min(), targets.min())
+            ssim_data_range = (batch_max - batch_min).clamp_min(torch.finfo(torch.float32).eps)
+            ssim_data_range = ssim_data_range.to(generated_predictions.dtype)
+        else:
+            ssim_data_range = self.data_range
+
+        ssim = structural_similarity_index_measure(
+            preds=generated_predictions,
+            target=targets,
+            data_range=ssim_data_range,
+        )
+        ssim_loss = 1.0 - ssim
+        total = l1 + self.ssim_weight * ssim_loss
+        return {"l1": l1, "ssim": ssim_loss, "total": total}

--- a/losses/__init__.py
+++ b/losses/__init__.py
@@ -1,2 +1,3 @@
 from .L1Loss import L1Loss
 from .L1SSIMLoss import L1SSIMLoss
+from .l1_ssim import compute_l1_ssim_mean_components

--- a/losses/__init__.py
+++ b/losses/__init__.py
@@ -1,1 +1,2 @@
 from .L1Loss import L1Loss
+from .L1SSIMLoss import L1SSIMLoss

--- a/losses/l1_ssim.py
+++ b/losses/l1_ssim.py
@@ -1,0 +1,101 @@
+from typing import Optional
+
+import torch
+from torchmetrics.functional.image import structural_similarity_index_measure
+
+
+def validate_prediction_shapes(
+    generated_predictions: torch.Tensor,
+    targets: torch.Tensor,
+) -> None:
+    """Validate that prediction and target tensors can be compared directly."""
+
+    if generated_predictions.shape != targets.shape:
+        raise ValueError("The generated predictions and targets must be the same shape.")
+
+
+def resolve_ssim_data_range(
+    generated_predictions: torch.Tensor,
+    targets: torch.Tensor,
+    data_range: Optional[float] = None,
+) -> torch.Tensor | float:
+    """Return a positive SSIM data range for the current tensors."""
+
+    if data_range is not None:
+        return data_range
+
+    batch_max = torch.maximum(generated_predictions.max(), targets.max())
+    batch_min = torch.minimum(generated_predictions.min(), targets.min())
+    return (batch_max - batch_min).clamp_min(
+        torch.finfo(generated_predictions.dtype).eps
+    )
+
+
+def compute_l1_ssim_mean_components(
+    generated_predictions: torch.Tensor,
+    targets: torch.Tensor,
+    ssim_weight: float,
+    data_range: Optional[float] = None,
+) -> dict[str, torch.Tensor]:
+    """Compute mean L1, SSIM loss, and total loss for one batch."""
+
+    validate_prediction_shapes(
+        generated_predictions=generated_predictions,
+        targets=targets,
+    )
+    l1 = torch.nn.functional.l1_loss(generated_predictions, targets, reduction="mean")
+    ssim = structural_similarity_index_measure(
+        preds=generated_predictions,
+        target=targets,
+        data_range=resolve_ssim_data_range(
+            generated_predictions=generated_predictions,
+            targets=targets,
+            data_range=data_range,
+        ),
+    )
+    ssim_loss = 1.0 - ssim
+    total = l1 + ssim_weight * ssim_loss
+    return {"l1": l1, "ssim": ssim_loss, "total": total}
+
+
+def compute_l1_per_sample(
+    generated_predictions: torch.Tensor,
+    targets: torch.Tensor,
+) -> torch.Tensor:
+    """Compute one mean absolute error value per sample."""
+
+    validate_prediction_shapes(
+        generated_predictions=generated_predictions,
+        targets=targets,
+    )
+    abs_error = torch.abs(generated_predictions - targets)
+    return abs_error.reshape(abs_error.shape[0], -1).mean(dim=1)
+
+
+def compute_ssim_loss_per_sample(
+    generated_predictions: torch.Tensor,
+    targets: torch.Tensor,
+    data_range: Optional[float] = None,
+) -> torch.Tensor:
+    """Compute one ``1 - SSIM`` value per sample."""
+
+    validate_prediction_shapes(
+        generated_predictions=generated_predictions,
+        targets=targets,
+    )
+    per_sample_ssim = structural_similarity_index_measure(
+        preds=generated_predictions,
+        target=targets,
+        data_range=resolve_ssim_data_range(
+            generated_predictions=generated_predictions,
+            targets=targets,
+            data_range=data_range,
+        ),
+        reduction="none",
+    ).reshape(-1)
+    finite_ssim = torch.where(
+        torch.isfinite(per_sample_ssim),
+        per_sample_ssim,
+        torch.tensor(0.0, device=generated_predictions.device, dtype=generated_predictions.dtype),
+    )
+    return 1.0 - finite_ssim

--- a/losses/l1_ssim.py
+++ b/losses/l1_ssim.py
@@ -8,7 +8,15 @@ def validate_prediction_shapes(
     generated_predictions: torch.Tensor,
     targets: torch.Tensor,
 ) -> None:
-    """Validate that prediction and target tensors can be compared directly."""
+    """Validate that prediction and target tensors can be compared directly.
+
+    Args:
+        generated_predictions: Model predictions.
+        targets: Ground-truth targets.
+
+    Raises:
+        ValueError: If the tensors do not have matching shapes.
+    """
 
     if generated_predictions.shape != targets.shape:
         raise ValueError("The generated predictions and targets must be the same shape.")
@@ -19,11 +27,23 @@ def resolve_ssim_data_range(
     targets: torch.Tensor,
     data_range: Optional[float] = None,
 ) -> torch.Tensor | float:
-    """Return a positive SSIM data range for the current tensors."""
+    """Return a positive SSIM data range for the current tensors.
+
+    Args:
+        generated_predictions: Model predictions.
+        targets: Ground-truth targets.
+        data_range: Optional fixed intensity range for SSIM.
+
+    Returns:
+        Either the caller-provided float range or a scalar tensor derived from
+        the current prediction/target pair.
+    """
 
     if data_range is not None:
         return data_range
 
+    # Derive a positive SSIM range from the current batch so the objective can
+    # operate directly in z-score space without a fixed intensity bound.
     batch_max = torch.maximum(generated_predictions.max(), targets.max())
     batch_min = torch.minimum(generated_predictions.min(), targets.min())
     return (batch_max - batch_min).clamp_min(
@@ -37,7 +57,21 @@ def compute_l1_ssim_mean_components(
     ssim_weight: float,
     data_range: Optional[float] = None,
 ) -> dict[str, torch.Tensor]:
-    """Compute mean L1, SSIM loss, and total loss for one batch."""
+    """Compute mean L1, SSIM loss, and total loss for one batch.
+
+    Args:
+        generated_predictions: Model predictions.
+        targets: Ground-truth targets with matching shape.
+        ssim_weight: Multiplier applied to ``1 - ssim``.
+        data_range: Optional fixed intensity range for SSIM.
+
+    Returns:
+        Dictionary containing scalar ``l1``, ``ssim``, and ``total`` loss
+        components, where ``ssim`` stores ``1 - SSIM``.
+
+    Raises:
+        ValueError: If prediction and target shapes differ.
+    """
 
     validate_prediction_shapes(
         generated_predictions=generated_predictions,
@@ -62,7 +96,18 @@ def compute_l1_per_sample(
     generated_predictions: torch.Tensor,
     targets: torch.Tensor,
 ) -> torch.Tensor:
-    """Compute one mean absolute error value per sample."""
+    """Compute one mean absolute error value per sample.
+
+    Args:
+        generated_predictions: Model predictions.
+        targets: Ground-truth targets with matching shape.
+
+    Returns:
+        Tensor of shape ``[batch_size]`` containing one L1 value per sample.
+
+    Raises:
+        ValueError: If prediction and target shapes differ.
+    """
 
     validate_prediction_shapes(
         generated_predictions=generated_predictions,
@@ -77,7 +122,20 @@ def compute_ssim_loss_per_sample(
     targets: torch.Tensor,
     data_range: Optional[float] = None,
 ) -> torch.Tensor:
-    """Compute one ``1 - SSIM`` value per sample."""
+    """Compute one ``1 - SSIM`` value per sample.
+
+    Args:
+        generated_predictions: Model predictions.
+        targets: Ground-truth targets with matching shape.
+        data_range: Optional fixed intensity range for SSIM.
+
+    Returns:
+        Tensor of shape ``[batch_size]`` containing one SSIM-loss value per
+        sample.
+
+    Raises:
+        ValueError: If prediction and target shapes differ.
+    """
 
     validate_prediction_shapes(
         generated_predictions=generated_predictions,

--- a/losses/l1_ssim.py
+++ b/losses/l1_ssim.py
@@ -70,8 +70,14 @@ def compute_l1_ssim_mean_components(
         components, where ``ssim`` stores ``-1 * SSIM``.
 
     Raises:
-        ValueError: If prediction and target shapes differ.
+        ValueError: If prediction and target shapes differ, ``ssim_weight`` is
+            negative, or ``data_range`` is not positive when provided.
     """
+
+    if ssim_weight < 0:
+        raise ValueError("ssim_weight must be non-negative")
+    if data_range is not None and data_range <= 0:
+        raise ValueError("data_range must be positive when provided")
 
     validate_prediction_shapes(
         generated_predictions=generated_predictions,

--- a/losses/l1_ssim.py
+++ b/losses/l1_ssim.py
@@ -62,12 +62,12 @@ def compute_l1_ssim_mean_components(
     Args:
         generated_predictions: Model predictions.
         targets: Ground-truth targets with matching shape.
-        ssim_weight: Multiplier applied to ``1 - ssim``.
+        ssim_weight: Multiplier applied to ``-1 * ssim``.
         data_range: Optional fixed intensity range for SSIM.
 
     Returns:
         Dictionary containing scalar ``l1``, ``ssim``, and ``total`` loss
-        components, where ``ssim`` stores ``1 - SSIM``.
+        components, where ``ssim`` stores ``-1 * SSIM``.
 
     Raises:
         ValueError: If prediction and target shapes differ.
@@ -87,7 +87,7 @@ def compute_l1_ssim_mean_components(
             data_range=data_range,
         ),
     )
-    ssim_loss = 1.0 - ssim
+    ssim_loss = -1.0 * ssim
     total = l1 + ssim_weight * ssim_loss
     return {"l1": l1, "ssim": ssim_loss, "total": total}
 
@@ -122,7 +122,7 @@ def compute_ssim_loss_per_sample(
     targets: torch.Tensor,
     data_range: Optional[float] = None,
 ) -> torch.Tensor:
-    """Compute one ``1 - SSIM`` value per sample.
+    """Compute one ``-1 * SSIM`` value per sample.
 
     Args:
         generated_predictions: Model predictions.
@@ -156,4 +156,4 @@ def compute_ssim_loss_per_sample(
         per_sample_ssim,
         torch.tensor(0.0, device=generated_predictions.device, dtype=generated_predictions.dtype),
     )
-    return 1.0 - finite_ssim
+    return -1.0 * finite_ssim

--- a/metrics/L1SSIMLossMetric.py
+++ b/metrics/L1SSIMLossMetric.py
@@ -18,7 +18,21 @@ class L1SSIMLossMetric(AbstractMetric):
         use_logits: bool = True,
         device: Union[str, torch.device] = "cuda",
     ):
-        """Configure epoch-level mixed-loss accumulation."""
+        """Configure epoch-level mixed-loss accumulation.
+
+        Args:
+            ssim_weight: Multiplier applied to ``1 - ssim``.
+            data_range: Optional fixed intensity range for SSIM. If omitted, the
+                range is derived from each evaluation batch.
+            use_logits: Whether caller should provide logits instead of
+                postprocessed outputs. This defaults to ``True`` so model
+                selection matches the z-score training objective.
+            device: Device for accumulation buffers.
+
+        Raises:
+            ValueError: If ``ssim_weight`` is negative or ``data_range`` is not
+                positive when provided.
+        """
 
         super().__init__()
         if ssim_weight < 0:
@@ -47,7 +61,16 @@ class L1SSIMLossMetric(AbstractMetric):
         targets: torch.Tensor,
         **kwargs,
     ) -> None:
-        """Accumulate per-sample mixed-loss statistics for one evaluation batch."""
+        """Accumulate per-sample mixed-loss statistics for one evaluation batch.
+
+        Args:
+            generated_predictions: Model predictions.
+            targets: Ground-truth targets with matching shape.
+            **kwargs: Additional unused metric arguments.
+
+        Raises:
+            ValueError: If prediction and target shapes differ.
+        """
 
         per_sample_l1 = compute_l1_per_sample(
             generated_predictions=generated_predictions,
@@ -71,7 +94,12 @@ class L1SSIMLossMetric(AbstractMetric):
         self.forward(generated_predictions=generated_predictions, targets=targets, **kwargs)
 
     def compute(self) -> dict[str, float]:
-        """Compute averaged mixed-loss values and standard deviations."""
+        """Compute averaged mixed-loss values and standard deviations.
+
+        Returns:
+            Dictionary containing mean and std values for the L1, SSIM-loss, and
+            total-loss components.
+        """
 
         l1_stats = self.l1_stats.compute()
         ssim_stats = self.ssim_stats.compute()

--- a/metrics/L1SSIMLossMetric.py
+++ b/metrics/L1SSIMLossMetric.py
@@ -21,7 +21,7 @@ class L1SSIMLossMetric(AbstractMetric):
         """Configure epoch-level mixed-loss accumulation.
 
         Args:
-            ssim_weight: Multiplier applied to ``1 - ssim``.
+            ssim_weight: Multiplier applied to ``-1 * ssim``.
             data_range: Optional fixed intensity range for SSIM. If omitted, the
                 range is derived from each evaluation batch.
             use_logits: Whether caller should provide logits instead of
@@ -97,7 +97,7 @@ class L1SSIMLossMetric(AbstractMetric):
         """Compute averaged mixed-loss values and standard deviations.
 
         Returns:
-            Dictionary containing mean and std values for the L1, SSIM-loss, and
+            Dictionary containing mean and std values for the L1, SSIM-derived, and
             total-loss components.
         """
 

--- a/metrics/L1SSIMLossMetric.py
+++ b/metrics/L1SSIMLossMetric.py
@@ -1,0 +1,99 @@
+from typing import Optional, Union
+
+import torch
+
+from losses.l1_ssim import compute_l1_per_sample, compute_ssim_loss_per_sample
+
+from .AbstractMetric import AbstractMetric
+from .utils.streaming_stats import StreamingScalarStats
+
+
+class L1SSIMLossMetric(AbstractMetric):
+    """Accumulate z-score-space L1, SSIM loss, and total loss for evaluation."""
+
+    def __init__(
+        self,
+        ssim_weight: float,
+        data_range: Optional[float] = None,
+        use_logits: bool = True,
+        device: Union[str, torch.device] = "cuda",
+    ):
+        """Configure epoch-level mixed-loss accumulation."""
+
+        super().__init__()
+        if ssim_weight < 0:
+            raise ValueError("ssim_weight must be non-negative")
+        if data_range is not None and data_range <= 0:
+            raise ValueError("data_range must be positive when provided")
+
+        self.ssim_weight = float(ssim_weight)
+        self.data_range = None if data_range is None else float(data_range)
+        self.use_logits = use_logits
+        self.device = (
+            device if isinstance(device, torch.device) else torch.device(device)
+        )
+        self.reset()
+
+    def reset(self):
+        """Reset running loss accumulators used for epoch-level logging."""
+
+        self.l1_stats = StreamingScalarStats(device=self.device)
+        self.ssim_stats = StreamingScalarStats(device=self.device)
+        self.total_stats = StreamingScalarStats(device=self.device)
+
+    def forward(
+        self,
+        generated_predictions: torch.Tensor,
+        targets: torch.Tensor,
+        **kwargs,
+    ) -> None:
+        """Accumulate per-sample mixed-loss statistics for one evaluation batch."""
+
+        per_sample_l1 = compute_l1_per_sample(
+            generated_predictions=generated_predictions,
+            targets=targets,
+        )
+        per_sample_ssim = compute_ssim_loss_per_sample(
+            generated_predictions=generated_predictions,
+            targets=targets,
+            data_range=self.data_range,
+        )
+        per_sample_total = per_sample_l1 + self.ssim_weight * per_sample_ssim
+
+        self.l1_stats.update(per_sample_l1)
+        self.ssim_stats.update(per_sample_ssim)
+        self.total_stats.update(per_sample_total)
+        return None
+
+    def update(self, generated_predictions: torch.Tensor, targets: torch.Tensor, **kwargs) -> None:
+        """Alias for state updates to align with TorchMetrics-like API."""
+
+        self.forward(generated_predictions=generated_predictions, targets=targets, **kwargs)
+
+    def compute(self) -> dict[str, float]:
+        """Compute averaged mixed-loss values and standard deviations."""
+
+        l1_stats = self.l1_stats.compute()
+        ssim_stats = self.ssim_stats.compute()
+        total_stats = self.total_stats.compute()
+        return {
+            "loss_l1": l1_stats["mean"],
+            "loss_l1_std": l1_stats["std"],
+            "loss_ssim": ssim_stats["mean"],
+            "loss_ssim_std": ssim_stats["std"],
+            self.metric_name: total_stats["mean"],
+            f"{self.metric_name}_std": total_stats["std"],
+        }
+
+    @property
+    def metric_name(self) -> str:
+        """Base metric key used for model selection and logging."""
+
+        return "loss_total"
+
+    def get_metric_data(self) -> dict[str, float]:
+        """Compute accumulated loss stats and reset state."""
+
+        metric_data = self.compute()
+        self.reset()
+        return metric_data

--- a/train.py
+++ b/train.py
@@ -259,6 +259,8 @@ class OptimizationManager:
             1e-3 / math.sqrt(max_batch_size),
             log=True,
         )
+        # Keep the auxiliary SSIM term meaningful without overwhelming the L1
+        # objective early in training.
         ssim_weight = trial.suggest_float("ssim_weight", 1e-3, 1e-1, log=True)
         lr = lr_factor * math.sqrt(batch_size)
         eval_batch_size = batch_size if requested_eval_batch_size is None else requested_eval_batch_size

--- a/train.py
+++ b/train.py
@@ -27,8 +27,8 @@ from datasets.dataset_00.utils.CropCacheBuilder import (
 from datasets.dataset_00.utils.ImagePostProcessor import ImagePostProcessor
 from datasets.dataset_00.utils.ImagePreProcessor import ImagePreProcessor
 from losses.L1SSIMLoss import L1SSIMLoss
-from metrics.L1 import L1
 from metrics.L2 import L2
+from metrics.L1SSIMLossMetric import L1SSIMLossMetric
 from metrics.PearsonCorrelation import PearsonCorrelation
 from metrics.PSNR import PSNR
 from metrics.SSIM import SSIM
@@ -287,7 +287,7 @@ class OptimizationManager:
         }
 
         loss_trainer = L1SSIMLoss(ssim_weight=ssim_weight)
-        loss_callbacks = L1(device=device)
+        loss_callbacks = L1SSIMLossMetric(ssim_weight=ssim_weight, device=device)
         metrics = [
             L2(device=device),
             PSNR(device=device, max_pixel_value=image_specs["target_max_pixel_value"]),

--- a/train.py
+++ b/train.py
@@ -252,16 +252,12 @@ class OptimizationManager:
 
         # Couple learning rate to batch size so Optuna searches a scaling factor
         # while the derived rate stays within the previous learning-rate bounds.
-        batch_size = trial.suggest_int("batch_size", 1, max_batch_size)
-        lr_factor = trial.suggest_float(
-            "lr_factor",
-            1e-5,
-            1e-3 / math.sqrt(max_batch_size),
-            log=True,
-        )
+        batch_size = 4
+        lr_factor = 5.983642900712674e-05
+
         # Keep the auxiliary SSIM term meaningful without overwhelming the L1
         # objective early in training.
-        ssim_weight = trial.suggest_float("ssim_weight", 1e-3, 1.0, log=True)
+        ssim_weight = 0.9812443957944074
         lr = lr_factor * math.sqrt(batch_size)
         eval_batch_size = batch_size if requested_eval_batch_size is None else requested_eval_batch_size
 
@@ -481,7 +477,7 @@ val_image_prediction_saver = SaveEpochCrops(
 )
 
 callbacks_args = {
-    "early_stopping_counter_threshold": 20,
+    "early_stopping_counter_threshold": 300,
     "image_savers": (
         [train_image_prediction_saver, val_image_prediction_saver]
         if args.enable_image_savers == 1

--- a/train.py
+++ b/train.py
@@ -287,6 +287,8 @@ class OptimizationManager:
         }
 
         loss_trainer = L1SSIMLoss(ssim_weight=ssim_weight)
+        # Keep checkpoint selection aligned with the z-score training objective
+        # while denormalized image-quality metrics continue to be logged separately.
         loss_callbacks = L1SSIMLossMetric(ssim_weight=ssim_weight, device=device)
         metrics = [
             L2(device=device),

--- a/train.py
+++ b/train.py
@@ -261,7 +261,7 @@ class OptimizationManager:
         )
         # Keep the auxiliary SSIM term meaningful without overwhelming the L1
         # objective early in training.
-        ssim_weight = trial.suggest_float("ssim_weight", 1e-3, 1e-1, log=True)
+        ssim_weight = trial.suggest_float("ssim_weight", 1e-3, 1.0, log=True)
         lr = lr_factor * math.sqrt(batch_size)
         eval_batch_size = batch_size if requested_eval_batch_size is None else requested_eval_batch_size
 

--- a/train.py
+++ b/train.py
@@ -26,7 +26,7 @@ from datasets.dataset_00.utils.CropCacheBuilder import (
     ensure_dapi_to_gold_cache, load_cache_manifest)
 from datasets.dataset_00.utils.ImagePostProcessor import ImagePostProcessor
 from datasets.dataset_00.utils.ImagePreProcessor import ImagePreProcessor
-from losses.L1Loss import L1Loss
+from losses.L1SSIMLoss import L1SSIMLoss
 from metrics.L1 import L1
 from metrics.L2 import L2
 from metrics.PearsonCorrelation import PearsonCorrelation
@@ -259,6 +259,7 @@ class OptimizationManager:
             1e-3 / math.sqrt(max_batch_size),
             log=True,
         )
+        ssim_weight = trial.suggest_float("ssim_weight", 1e-3, 1e-1, log=True)
         lr = lr_factor * math.sqrt(batch_size)
         eval_batch_size = batch_size if requested_eval_batch_size is None else requested_eval_batch_size
 
@@ -283,7 +284,7 @@ class OptimizationManager:
             "betas": (0.5, 0.999),
         }
 
-        loss_trainer = L1Loss()
+        loss_trainer = L1SSIMLoss(ssim_weight=ssim_weight)
         loss_callbacks = L1(device=device)
         metrics = [
             L2(device=device),
@@ -302,6 +303,7 @@ class OptimizationManager:
             mlflow.log_params({f"optimizer_{k}": v for k, v in opt_params.items()})
             mlflow.log_param("batch_size", batch_size)
             mlflow.log_param("lr_factor", lr_factor)
+            mlflow.log_param("ssim_weight", ssim_weight)
             mlflow.log_param("eval_batch_size", eval_batch_size)
             mlflow.log_param("eval_use_amp", int(eval_use_amp))
             mlflow.log_param("train_use_amp", int(train_use_amp))
@@ -357,7 +359,8 @@ Optimization of a DAPI-to-Gold image-to-image translation model with:
 - Single 2D crop input and single 2D crop target
 - Cache-backed filtered nucleus crops generated from the configured data directory
 - Train-split z-score normalization for inputs and targets
-- L1 optimization objective in z-score space with denormalized L2, PSNR, SSIM,
+- L1 plus Optuna-weighted SSIM optimization objective in z-score space with
+  denormalized L2, PSNR, SSIM,
   and Pearson correlation metric logging
 """
 mlflow.set_tag("mlflow.note.content", description)

--- a/train.py
+++ b/train.py
@@ -481,7 +481,7 @@ val_image_prediction_saver = SaveEpochCrops(
 )
 
 callbacks_args = {
-    "early_stopping_counter_threshold": 15,
+    "early_stopping_counter_threshold": 20,
     "image_savers": (
         [train_image_prediction_saver, val_image_prediction_saver]
         if args.enable_image_savers == 1

--- a/training_orchestration.sh
+++ b/training_orchestration.sh
@@ -10,8 +10,8 @@ mlflow run . -e train_model \
   --env-manager local \
   --experiment-name "u2os_nuclear_speckle_prediction_dapi_gold" \
   -P dataset=u2os \
-  -P epochs=100 \
-  -P n_trials=15 \
+  -P epochs=300 \
+  -P n_trials=1 \
   -P max_train_batches=-1 \
   -P max_eval_batches=-1 \
   -P eval_batch_size=10 \


### PR DESCRIPTION
Adds a mixed L1 plus auxiliary SSIM training objective, with the SSIM contribution tuned per trial by Optuna. The branch also logs batch-level L1, SSIM, and total losses during training, and aligns validation-based checkpoint selection and patience tracking with the same z-score-space total loss used for optimization, while keeping the existing denormalized image-quality metrics unchanged.