### PR TITLE
Robust Percentile Normalization

### DIFF
--- a/datasets/dataset_00/utils/ImagePostProcessor.py
+++ b/datasets/dataset_00/utils/ImagePostProcessor.py
@@ -6,49 +6,51 @@ class ImagePostProcessor:
 
     def __init__(
         self,
-        input_mean: float,
-        input_std: float,
-        target_mean: float,
-        target_std: float,
+        input_lower_value: float,
+        input_upper_value: float,
+        target_lower_value: float,
+        target_upper_value: float,
     ):
-        """Store train-split normalization statistics for inverse transforms.
+        """Store train-split robust percentile bounds for inverse transforms.
 
         Args:
-            input_mean: Mean intensity used to z-score inputs.
-            input_std: Standard deviation used to z-score inputs.
-            target_mean: Mean intensity used to z-score targets.
-            target_std: Standard deviation used to z-score targets.
+            input_lower_value: Lower train-split clipping bound for inputs.
+            input_upper_value: Upper train-split clipping bound for inputs.
+            target_lower_value: Lower train-split clipping bound for targets.
+            target_upper_value: Upper train-split clipping bound for targets.
 
         Raises:
-            ValueError: If any standard deviation is non-positive.
+            ValueError: If any percentile bounds are not strictly increasing.
         """
 
-        if input_std <= 0 or target_std <= 0:
-            raise ValueError("Z-score standard deviations must be positive")
+        if input_lower_value >= input_upper_value or target_lower_value >= target_upper_value:
+            raise ValueError("Robust percentile normalization bounds must be increasing")
 
-        self.input_mean = float(input_mean)
-        self.input_std = float(input_std)
-        self.target_mean = float(target_mean)
-        self.target_std = float(target_std)
+        self.input_lower_value = float(input_lower_value)
+        self.input_upper_value = float(input_upper_value)
+        self.target_lower_value = float(target_lower_value)
+        self.target_upper_value = float(target_upper_value)
 
     def __call__(self, generated_prediction: torch.Tensor) -> torch.Tensor:
-        """Return model predictions in training space.
+        """Return model predictions in normalized training space.
 
         Args:
             generated_prediction: Raw model output tensor.
 
         Returns:
-            Prediction tensor in z-score space.
+            Prediction tensor in robust percentile-normalized space.
         """
 
         return generated_prediction
 
     def denormalize_input(self, image: torch.Tensor) -> torch.Tensor:
-        """Map z-scored input tensors back to original intensity space."""
+        """Map normalized input tensors back to original intensity space."""
 
-        return image.float() * self.input_std + self.input_mean
+        image = image.float().clamp(0.0, 1.0)
+        return image * (self.input_upper_value - self.input_lower_value) + self.input_lower_value
 
     def denormalize_target(self, image: torch.Tensor) -> torch.Tensor:
-        """Map z-scored target or prediction tensors back to original intensity space."""
+        """Map normalized target or prediction tensors back to original intensity space."""
 
-        return image.float() * self.target_std + self.target_mean
+        image = image.float().clamp(0.0, 1.0)
+        return image * (self.target_upper_value - self.target_lower_value) + self.target_lower_value

--- a/datasets/dataset_00/utils/ImagePreProcessor.py
+++ b/datasets/dataset_00/utils/ImagePreProcessor.py
@@ -32,26 +32,42 @@ class ImagePreProcessor:
 
     def set_image_specs(
         self,
-        input_mean: float | None = None,
-        input_std: float | None = None,
-        target_mean: float | None = None,
-        target_std: float | None = None,
+        input_percentile_lower_value: float | None = None,
+        input_percentile_upper_value: float | None = None,
+        target_percentile_lower_value: float | None = None,
+        target_percentile_upper_value: float | None = None,
         **kwargs,
     ) -> None:
-        """Store z-score normalization statistics inferred from training data.
+        """Store robust percentile normalization bounds inferred from training data.
 
         Args:
-            input_mean: Mean pixel intensity used to center inputs.
-            input_std: Standard deviation used to scale inputs.
-            target_mean: Mean pixel intensity used to center targets.
-            target_std: Standard deviation used to scale targets.
+            input_percentile_lower_value: Lower train-split clipping bound for inputs.
+            input_percentile_upper_value: Upper train-split clipping bound for inputs.
+            target_percentile_lower_value: Lower train-split clipping bound for targets.
+            target_percentile_upper_value: Upper train-split clipping bound for targets.
             **kwargs: Additional image spec keys ignored by this preprocessor.
         """
 
-        self.input_mean = None if input_mean is None else float(input_mean)
-        self.input_std = None if input_std is None else float(input_std)
-        self.target_mean = None if target_mean is None else float(target_mean)
-        self.target_std = None if target_std is None else float(target_std)
+        self.input_lower_value = (
+            None
+            if input_percentile_lower_value is None
+            else float(input_percentile_lower_value)
+        )
+        self.input_upper_value = (
+            None
+            if input_percentile_upper_value is None
+            else float(input_percentile_upper_value)
+        )
+        self.target_lower_value = (
+            None
+            if target_percentile_lower_value is None
+            else float(target_percentile_lower_value)
+        )
+        self.target_upper_value = (
+            None
+            if target_percentile_upper_value is None
+            else float(target_percentile_upper_value)
+        )
 
     def format_img(self, img: np.ndarray) -> torch.Tensor:
         """Convert a normalized 2D numpy image into a channel-first tensor.
@@ -82,8 +98,7 @@ class ImagePreProcessor:
             Dictionary containing formatted ``input_image`` and ``target_image`` tensors.
 
         Raises:
-            ValueError: If z-score statistics are missing or standard deviations
-                are non-positive.
+            ValueError: If robust percentile bounds are missing or invalid.
         """
 
         if self.input_transform is not None:
@@ -92,13 +107,32 @@ class ImagePreProcessor:
         if self.target_transform is not None:
             target_img = self.target_transform(image=target_img)["image"]
 
-        if None in (self.input_mean, self.input_std, self.target_mean, self.target_std):
-            raise ValueError("Z-score normalization statistics must be set before loading data")
-        if self.input_std <= 0 or self.target_std <= 0:
-            raise ValueError("Z-score standard deviations must be positive")
+        if None in (
+            self.input_lower_value,
+            self.input_upper_value,
+            self.target_lower_value,
+            self.target_upper_value,
+        ):
+            raise ValueError(
+                "Robust percentile normalization bounds must be set before loading data"
+            )
+        if (
+            self.input_lower_value >= self.input_upper_value
+            or self.target_lower_value >= self.target_upper_value
+        ):
+            raise ValueError("Robust percentile normalization bounds must be increasing")
 
-        input_img = (input_img - self.input_mean) / self.input_std
-        target_img = (target_img - self.target_mean) / self.target_std
+        input_img = np.clip(input_img, self.input_lower_value, self.input_upper_value)
+        input_img = (input_img - self.input_lower_value) / (
+            self.input_upper_value - self.input_lower_value
+        )
+        input_img = np.clip(input_img, 0.0, 1.0)
+
+        target_img = np.clip(target_img, self.target_lower_value, self.target_upper_value)
+        target_img = (target_img - self.target_lower_value) / (
+            self.target_upper_value - self.target_lower_value
+        )
+        target_img = np.clip(target_img, 0.0, 1.0)
 
         return {
             "input_image": self.format_img(input_img),

--- a/losses/l1_ssim.py
+++ b/losses/l1_ssim.py
@@ -43,7 +43,7 @@ def resolve_ssim_data_range(
         return data_range
 
     # Derive a positive SSIM range from the current batch so the objective can
-    # operate directly in z-score space without a fixed intensity bound.
+    # operate directly in normalized space without a fixed intensity bound.
     batch_max = torch.maximum(generated_predictions.max(), targets.max())
     batch_min = torch.minimum(generated_predictions.min(), targets.min())
     return (batch_max - batch_min).clamp_min(

--- a/metrics/L1SSIMLossMetric.py
+++ b/metrics/L1SSIMLossMetric.py
@@ -9,7 +9,7 @@ from .utils.streaming_stats import StreamingScalarStats
 
 
 class L1SSIMLossMetric(AbstractMetric):
-    """Accumulate z-score-space L1, SSIM loss, and total loss for evaluation."""
+    """Accumulate normalized-space L1, SSIM loss, and total loss for evaluation."""
 
     def __init__(
         self,
@@ -26,7 +26,7 @@ class L1SSIMLossMetric(AbstractMetric):
                 range is derived from each evaluation batch.
             use_logits: Whether caller should provide logits instead of
                 postprocessed outputs. This defaults to ``True`` so model
-                selection matches the z-score training objective.
+                selection matches the normalized training objective.
             device: Device for accumulation buffers.
 
         Raises:

--- a/train.py
+++ b/train.py
@@ -156,57 +156,60 @@ max_batch_size = 8
 def compute_training_image_stats(
     manifest_rows: list[dict[str, str]],
     train_indices: list[int],
+    input_lower_percentile: float,
+    input_upper_percentile: float,
+    target_lower_percentile: float,
+    target_upper_percentile: float,
 ) -> dict[str, float]:
-    """Compute train-split image mean and std for z-score normalization.
+    """Compute train-split robust percentile bounds for normalization.
 
     Args:
         manifest_rows: Full manifest rows backing the crop dataset.
         train_indices: Dataset indices assigned to the training split.
 
     Returns:
-        Dictionary containing train-split input/target means and standard deviations.
+        Dictionary containing train-split input/target percentile bounds.
 
     Raises:
-        ValueError: If the training split is empty or any variance is non-positive.
+        ValueError: If the training split is empty or any percentile bounds collapse.
     """
 
     if not train_indices:
-        raise ValueError("Training split is empty; cannot compute z-score statistics.")
+        raise ValueError("Training split is empty; cannot compute percentile statistics.")
 
-    input_sum = 0.0
-    input_sum_sq = 0.0
-    target_sum = 0.0
-    target_sum_sq = 0.0
-    input_count = 0
-    target_count = 0
+    input_pixels: list[np.ndarray] = []
+    target_pixels: list[np.ndarray] = []
 
     for idx in train_indices:
         sample = manifest_rows[idx]
         input_image = tifffile.imread(sample["input_path"])
         target_image = tifffile.imread(sample["target_path"])
 
-        input_sum += float(input_image.sum(dtype=np.float64))
-        input_sum_sq += float(np.square(input_image, dtype=np.float64).sum())
-        target_sum += float(target_image.sum(dtype=np.float64))
-        target_sum_sq += float(np.square(target_image, dtype=np.float64).sum())
-        input_count += int(input_image.size)
-        target_count += int(target_image.size)
+        input_pixels.append(input_image.reshape(-1).astype(np.float32, copy=False))
+        target_pixels.append(target_image.reshape(-1).astype(np.float32, copy=False))
 
-    input_mean = input_sum / input_count
-    target_mean = target_sum / target_count
-    input_var = (input_sum_sq / input_count) - (input_mean**2)
-    target_var = (target_sum_sq / target_count) - (target_mean**2)
-    input_std = math.sqrt(max(input_var, 0.0))
-    target_std = math.sqrt(max(target_var, 0.0))
+    input_pixels_concat = np.concatenate(input_pixels)
+    target_pixels_concat = np.concatenate(target_pixels)
 
-    if input_std <= 0 or target_std <= 0:
-        raise ValueError("Training-split z-score standard deviations must be positive.")
+    input_lower_value = float(np.percentile(input_pixels_concat, input_lower_percentile))
+    input_upper_value = float(np.percentile(input_pixels_concat, input_upper_percentile))
+    target_lower_value = float(np.percentile(target_pixels_concat, target_lower_percentile))
+    target_upper_value = float(np.percentile(target_pixels_concat, target_upper_percentile))
+
+    if input_lower_value >= input_upper_value or target_lower_value >= target_upper_value:
+        raise ValueError(
+            "Training-split percentile bounds must be strictly increasing."
+        )
 
     return {
-        "input_mean": input_mean,
-        "input_std": input_std,
-        "target_mean": target_mean,
-        "target_std": target_std,
+        "input_lower_percentile": input_lower_percentile,
+        "input_upper_percentile": input_upper_percentile,
+        "input_percentile_lower_value": input_lower_value,
+        "input_percentile_upper_value": input_upper_value,
+        "target_lower_percentile": target_lower_percentile,
+        "target_upper_percentile": target_upper_percentile,
+        "target_percentile_lower_value": target_lower_value,
+        "target_percentile_upper_value": target_upper_value,
     }
 
 
@@ -287,7 +290,7 @@ class OptimizationManager:
         }
 
         loss_trainer = L1SSIMLoss(ssim_weight=ssim_weight)
-        # Keep checkpoint selection aligned with the z-score training objective
+        # Keep checkpoint selection aligned with the normalized training objective
         # while denormalized image-quality metrics continue to be logged separately.
         loss_callbacks = L1SSIMLossMetric(ssim_weight=ssim_weight, device=device)
         metrics = [
@@ -362,8 +365,8 @@ Optimization of a DAPI-to-Gold image-to-image translation model with:
 - ConvNeXtUNet Generator
 - Single 2D crop input and single 2D crop target
 - Cache-backed filtered nucleus crops generated from the configured data directory
-- Train-split z-score normalization for inputs and targets
-- L1 plus Optuna-weighted SSIM optimization objective in z-score space with
+- Train-split 1st/99th percentile normalization for inputs and targets
+- L1 plus Optuna-weighted SSIM optimization objective in normalized space with
   denormalized L2, PSNR, SSIM,
   and Pearson correlation metric logging
 """
@@ -427,23 +430,43 @@ bootstrap_hash_splitter = HashSplitter(
     val_frac=0.125,
 )
 bootstrap_hash_splitter.split_by_hash()
+input_lower_percentile = 1.0
+input_upper_percentile = 99.0
+target_lower_percentile = 1.0
+target_upper_percentile = 99.0
 training_stats = compute_training_image_stats(
     manifest_rows=manifest_nuclei,
     train_indices=bootstrap_hash_splitter.splits["train"],
+    input_lower_percentile=input_lower_percentile,
+    input_upper_percentile=input_upper_percentile,
+    target_lower_percentile=target_lower_percentile,
+    target_upper_percentile=target_upper_percentile,
 )
 image_specs = image_specs | training_stats
 
-mlflow.log_param("input_mean", image_specs["input_mean"])
-mlflow.log_param("input_std", image_specs["input_std"])
-mlflow.log_param("target_mean", image_specs["target_mean"])
-mlflow.log_param("target_std", image_specs["target_std"])
+mlflow.log_param("input_lower_percentile", image_specs["input_lower_percentile"])
+mlflow.log_param("input_upper_percentile", image_specs["input_upper_percentile"])
+mlflow.log_param(
+    "input_percentile_lower_value", image_specs["input_percentile_lower_value"]
+)
+mlflow.log_param(
+    "input_percentile_upper_value", image_specs["input_percentile_upper_value"]
+)
+mlflow.log_param("target_lower_percentile", image_specs["target_lower_percentile"])
+mlflow.log_param("target_upper_percentile", image_specs["target_upper_percentile"])
+mlflow.log_param(
+    "target_percentile_lower_value", image_specs["target_percentile_lower_value"]
+)
+mlflow.log_param(
+    "target_percentile_upper_value", image_specs["target_percentile_upper_value"]
+)
 
 image_preprocessor = ImagePreProcessor(image_specs=image_specs, device=device)
 image_postprocessor = ImagePostProcessor(
-    input_mean=image_specs["input_mean"],
-    input_std=image_specs["input_std"],
-    target_mean=image_specs["target_mean"],
-    target_std=image_specs["target_std"],
+    input_lower_value=image_specs["input_percentile_lower_value"],
+    input_upper_value=image_specs["input_percentile_upper_value"],
+    target_lower_value=image_specs["target_percentile_lower_value"],
+    target_upper_value=image_specs["target_percentile_upper_value"],
 )
 
 crop_image_dataset = CellCropToCropDataset(


### PR DESCRIPTION
This pr uses training-derived robust percentile normalization for training and validation, replacing the previous z-score standardization approach with clipped scaling based on the training split. The update also logs the learned percentile bounds in mlflow so the same normalization can be reused consistently during inference later.