### PR TITLE
MS-SSIM Joint Training Loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ In practice this allows training and evaluation inference behavior to be configu
 
 ## Loss and Metrics
 
-- Optimization loss: L1
+- Optimization loss: L1 plus MS-SSIM in normalized `[0, 1]` space with fixed `data_range=1.0`
 - Logged metrics: L1, L2, PSNR, SSIM, Pearson correlation
 
 Metrics are implemented in `metrics/` and logged through `callbacks/CallbackPipeline.py`.

--- a/losses/L1SSIMLoss.py
+++ b/losses/L1SSIMLoss.py
@@ -7,16 +7,16 @@ from .l1_ssim import compute_l1_ssim_mean_components
 
 
 class L1SSIMLoss(nn.Module):
-    """Composite training loss combining L1 and SSIM terms."""
+    """Composite training loss combining L1 and MS-SSIM terms."""
 
     loss_name = "l1_ssim"
 
     def __init__(self, ssim_weight: float, data_range: Optional[float] = None) -> None:
-        """Store SSIM weighting and optional fixed intensity range.
+        """Store MS-SSIM weighting and optional fixed intensity range.
 
         Args:
-            ssim_weight: Multiplier applied to ``-1 * ssim``.
-            data_range: Optional fixed data range for SSIM. If omitted, the
+            ssim_weight: Multiplier applied to ``-1 * ms_ssim``.
+            data_range: Optional fixed data range for MS-SSIM. If omitted, the
                 range is derived from the current batch.
 
         Raises:
@@ -38,7 +38,7 @@ class L1SSIMLoss(nn.Module):
         targets: torch.Tensor,
         **kwargs,
     ) -> dict[str, torch.Tensor]:
-        """Compute composite L1 and SSIM batch loss for one optimization step.
+        """Compute composite L1 and MS-SSIM batch loss for one optimization step.
 
         Args:
             generated_predictions: Model predictions.
@@ -47,7 +47,7 @@ class L1SSIMLoss(nn.Module):
 
         Returns:
             Dictionary containing scalar ``l1``, ``ssim``, and ``total`` loss
-            components, where ``ssim`` stores ``-1 * SSIM``.
+            components, where ``ssim`` stores ``-1 * MS-SSIM``.
 
         Raises:
             ValueError: If prediction and target shapes differ.

--- a/losses/l1_ssim.py
+++ b/losses/l1_ssim.py
@@ -1,7 +1,15 @@
 from typing import Optional
 
 import torch
-from torchmetrics.functional.image import structural_similarity_index_measure
+from torchmetrics.functional.image import (
+    multiscale_structural_similarity_index_measure,
+)
+
+
+# Default 5-scale MS-SSIM from TorchMetrics requires images larger than 160x160
+# with the standard 11x11 kernel, so use the first four canonical scale weights
+# for this repo's 128x128 crops.
+MS_SSIM_BETAS_128 = (0.0448, 0.2856, 0.3001, 0.2363)
 
 
 def validate_prediction_shapes(
@@ -27,12 +35,12 @@ def resolve_ssim_data_range(
     targets: torch.Tensor,
     data_range: Optional[float] = None,
 ) -> torch.Tensor | float:
-    """Return a positive SSIM data range for the current tensors.
+    """Return a positive MS-SSIM data range for the current tensors.
 
     Args:
         generated_predictions: Model predictions.
         targets: Ground-truth targets.
-        data_range: Optional fixed intensity range for SSIM.
+        data_range: Optional fixed intensity range for MS-SSIM.
 
     Returns:
         Either the caller-provided float range or a scalar tensor derived from
@@ -42,7 +50,7 @@ def resolve_ssim_data_range(
     if data_range is not None:
         return data_range
 
-    # Derive a positive SSIM range from the current batch so the objective can
+    # Derive a positive MS-SSIM range from the current batch so the objective can
     # operate directly in normalized space without a fixed intensity bound.
     batch_max = torch.maximum(generated_predictions.max(), targets.max())
     batch_min = torch.minimum(generated_predictions.min(), targets.min())
@@ -57,17 +65,17 @@ def compute_l1_ssim_mean_components(
     ssim_weight: float,
     data_range: Optional[float] = None,
 ) -> dict[str, torch.Tensor]:
-    """Compute mean L1, SSIM loss, and total loss for one batch.
+    """Compute mean L1, MS-SSIM loss, and total loss for one batch.
 
     Args:
         generated_predictions: Model predictions.
         targets: Ground-truth targets with matching shape.
-        ssim_weight: Multiplier applied to ``-1 * ssim``.
-        data_range: Optional fixed intensity range for SSIM.
+        ssim_weight: Multiplier applied to ``-1 * ms_ssim``.
+        data_range: Optional fixed intensity range for MS-SSIM.
 
     Returns:
         Dictionary containing scalar ``l1``, ``ssim``, and ``total`` loss
-        components, where ``ssim`` stores ``-1 * SSIM``.
+        components, where ``ssim`` stores ``-1 * MS-SSIM``.
 
     Raises:
         ValueError: If prediction and target shapes differ.
@@ -78,7 +86,7 @@ def compute_l1_ssim_mean_components(
         targets=targets,
     )
     l1 = torch.nn.functional.l1_loss(generated_predictions, targets, reduction="mean")
-    ssim = structural_similarity_index_measure(
+    ssim = multiscale_structural_similarity_index_measure(
         preds=generated_predictions,
         target=targets,
         data_range=resolve_ssim_data_range(
@@ -86,6 +94,7 @@ def compute_l1_ssim_mean_components(
             targets=targets,
             data_range=data_range,
         ),
+        betas=MS_SSIM_BETAS_128,
     )
     ssim_loss = -1.0 * ssim
     total = l1 + ssim_weight * ssim_loss
@@ -122,15 +131,15 @@ def compute_ssim_loss_per_sample(
     targets: torch.Tensor,
     data_range: Optional[float] = None,
 ) -> torch.Tensor:
-    """Compute one ``-1 * SSIM`` value per sample.
+    """Compute one ``-1 * MS-SSIM`` value per sample.
 
     Args:
         generated_predictions: Model predictions.
         targets: Ground-truth targets with matching shape.
-        data_range: Optional fixed intensity range for SSIM.
+        data_range: Optional fixed intensity range for MS-SSIM.
 
     Returns:
-        Tensor of shape ``[batch_size]`` containing one SSIM-loss value per
+        Tensor of shape ``[batch_size]`` containing one MS-SSIM-loss value per
         sample.
 
     Raises:
@@ -141,7 +150,7 @@ def compute_ssim_loss_per_sample(
         generated_predictions=generated_predictions,
         targets=targets,
     )
-    per_sample_ssim = structural_similarity_index_measure(
+    per_sample_ssim = multiscale_structural_similarity_index_measure(
         preds=generated_predictions,
         target=targets,
         data_range=resolve_ssim_data_range(
@@ -150,6 +159,7 @@ def compute_ssim_loss_per_sample(
             data_range=data_range,
         ),
         reduction="none",
+        betas=MS_SSIM_BETAS_128,
     ).reshape(-1)
     finite_ssim = torch.where(
         torch.isfinite(per_sample_ssim),

--- a/metrics/L1SSIMLossMetric.py
+++ b/metrics/L1SSIMLossMetric.py
@@ -9,7 +9,7 @@ from .utils.streaming_stats import StreamingScalarStats
 
 
 class L1SSIMLossMetric(AbstractMetric):
-    """Accumulate normalized-space L1, SSIM loss, and total loss for evaluation."""
+    """Accumulate normalized-space L1, MS-SSIM loss, and total loss for evaluation."""
 
     def __init__(
         self,
@@ -21,8 +21,8 @@ class L1SSIMLossMetric(AbstractMetric):
         """Configure epoch-level mixed-loss accumulation.
 
         Args:
-            ssim_weight: Multiplier applied to ``-1 * ssim``.
-            data_range: Optional fixed intensity range for SSIM. If omitted, the
+            ssim_weight: Multiplier applied to ``-1 * ms_ssim``.
+            data_range: Optional fixed intensity range for MS-SSIM. If omitted, the
                 range is derived from each evaluation batch.
             use_logits: Whether caller should provide logits instead of
                 postprocessed outputs. This defaults to ``True`` so model

--- a/train.py
+++ b/train.py
@@ -262,7 +262,7 @@ class OptimizationManager:
             1e-3 / math.sqrt(max_batch_size),
             log=True,
         )
-        # Keep the auxiliary SSIM term meaningful without overwhelming the L1
+        # Keep the auxiliary MS-SSIM term meaningful without overwhelming the L1
         # objective early in training.
         ssim_weight = trial.suggest_float("ssim_weight", 1e-3, 1.0, log=True)
         lr = lr_factor * math.sqrt(batch_size)
@@ -289,10 +289,15 @@ class OptimizationManager:
             "betas": (0.5, 0.999),
         }
 
-        loss_trainer = L1SSIMLoss(ssim_weight=ssim_weight)
-        # Keep checkpoint selection aligned with the normalized training objective
-        # while denormalized image-quality metrics continue to be logged separately.
-        loss_callbacks = L1SSIMLossMetric(ssim_weight=ssim_weight, device=device)
+        loss_trainer = L1SSIMLoss(ssim_weight=ssim_weight, data_range=1.0)
+        # Keep checkpoint selection aligned with the normalized L1 + MS-SSIM
+        # objective while denormalized image-quality metrics continue to be
+        # logged separately.
+        loss_callbacks = L1SSIMLossMetric(
+            ssim_weight=ssim_weight,
+            data_range=1.0,
+            device=device,
+        )
         metrics = [
             L2(device=device),
             PSNR(device=device, max_pixel_value=image_specs["target_max_pixel_value"]),
@@ -366,7 +371,7 @@ Optimization of a DAPI-to-Gold image-to-image translation model with:
 - Single 2D crop input and single 2D crop target
 - Cache-backed filtered nucleus crops generated from the configured data directory
 - Train-split 1st/99th percentile normalization for inputs and targets
-- L1 plus Optuna-weighted SSIM optimization objective in normalized space with
+- L1 plus Optuna-weighted MS-SSIM optimization objective in normalized space with
   denormalized L2, PSNR, SSIM,
   and Pearson correlation metric logging
 """


### PR DESCRIPTION
This pr updates the training objective to use a 4-scale MS-SSIM term alongside L1 loss for 128x128 normalized images.